### PR TITLE
OPENEUROPA-1584: Set code-review version and remove CHANGELOG.md.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "drupal/console": "~1.6",
         "drupal/drupal-extension": "~4.0",
-        "openeuropa/code-review": "dev-master",
+        "openeuropa/code-review": "^1.0.0-beta1",
         "openeuropa/composer-artifacts": "~0.1",
         "openeuropa/task-runner": "~1.0",
         "webflo/drupal-core-require-dev": "~8.6"

--- a/scripts/composer/SetupWizard.php
+++ b/scripts/composer/SetupWizard.php
@@ -91,6 +91,11 @@ class SetupWizard {
     unlink('.gitignore');
     rename('.gitignore.dist', '.gitignore');
 
+    // Remove the CHANGELOG.md.
+    if (file_exists('CHANGELOG.md')) {
+      unlink('CHANGELOG.md');
+    }
+
     // Remove the configuration related to the setup wizard.
     unset($config['scripts']['cleanup']);
     unset($config['scripts']['setup']);


### PR DESCRIPTION
## OPENEUROPA-1584

### Description

Set the correct version for code-review and remove the CHANGELOG.md if it exists.

### Change log

- Added: unlink for CHANGELOG. 
- Changed: Code-review version.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

