### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,7 +8,7 @@ default:
         - OpenEuropa\my_site\Context\DrupalContext
         - OpenEuropa\my_site\Context\FeatureContext
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       browser_name: '${selenium.browser}'
       javascript_session: 'selenium2'


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.