### PR TITLE
Include some required props in runner template.

### DIFF
--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -1,3 +1,8 @@
+project:
+  id: myproject
+  name: myname
+  mail:myemail
+  url: production_url
 drupal:
   root: "web"
   base_url: "http://web:8080/web"


### PR DESCRIPTION
## OPENEUROPA-0000

### Description

Toolkit require some minimum props to be available in each project in order to make it compatible with DIGIT infra. One example is the project id used by toolkit to grab the proper database from DIGIT ASDA service.