### PR TITLE
Remove the step 'phpdrone/composer-sa-checker'

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,12 +28,6 @@ pipeline:
     commands:
       - composer install --ansi --no-suggest --no-progress
 
-  # Check vulnerable packages @Sensiolabs.
-  test-composer-deps:
-    group: check-prepare
-    image: phpdrone/composer-sa-checker
-    lock_file: composer.lock
-
   # Install the drupal site.
   site-install:
     image: fpfis/httpd-php-dev:7.1


### PR DESCRIPTION
## Remove the step 'phpdrone/composer-sa-checker' 

### Description

We should remove this step on Drone because it needs a connection with outside and all tests on CI should work well without connnection.

### Change log

- Removed: the step 'phpdrone/composer-sa-checker'

