### PR TITLE
Add instructions to install from github in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,94 @@ using the following command:.
 ./vendor/bin/drush cex
 ```
 
+## Install and run the project from Github
+If you want to install and deploy Drupal Site Template in a local development environment with the Github codebase, here there is a set of steps to making it possible. 
+
+
+### **Prerequisites:**
++ Docker 
++ Docker Compose
+
+### **Installing Docker**
+
+```bash
+sudo apt install -y build-essential apt-transport-https ca-certificates jq curl software-properties-common file
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt update
+sudo apt install -y docker-ce
+sudo chmod 666 /var/run/docker*
+systemctl is-active docker
+```
+
+### **Installing Docker Compose**
+
+```bash
+VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
+DESTINATION=/usr/local/bin/docker-compose
+sudo curl -L https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-$(uname -s)-$(uname -m) -o $DESTINATION
+sudo chmod 755 $DESTINATION
+docker-compose --version
+```
+
+### **First:** You have to stop your Apache webserver, in order to free the port:80 
+
+```bash
+sudo /etc/init.d/apache2 stop
+```
+### **Second:** Clone the Drupal Site project inside your working directory
+
+```bash
+git clone https://github.com/openeuropa/drupal-site-template.git
+```
+
+### **Third:** Run the project (general and the web container for Drupal)
+
+```bash 
+cd drupal-site-template
+docker-compose up -d
+docker-compose exec web composer install
+```
+
+### **Fourth:** Get the ID of the web container and inspect it
+
+```bash
+docker ps
+docker container inspect IDCONTAINER
+```
+
+### **Fifth:** Get the IP of the container and load it in browser
+
+```bash
+sensible-browser IPCONTAINER:8080
+```
+
+### **Sixth:** Connect to the container
+
+```bash
+docker exec -it IDCONTAINER /bin/bash 
+```
+
+### **Seventh:** Run the installer / Task Runner
+
+```bash
+./vendor/bin/run toolkit:install-clean
+```
+
+### **Eighth:** Export configuration files from database to config/sync
+
+```bash
+./vendor/bin/drush cex
+```
+
+### **Ninth:** Visit your new project in
+
+```bash
+http://IPCONTAINER:8080/web
+```
+
+### **Happy Hacking!** 
+
 ## Drone
 
 A `.drone.yml` file is provided for running CI tests on Drone. Further details of how to set this up can be found in the


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

I add instructions to deploy Drupal Site Template from Github to a local development environment. 

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

