### PR TITLE
OPENEUROPA-2186: Put minimum version for symfony/browser-kit to ~4.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "webflo/drupal-core-require-dev": "~8.7"
     },
     "_readme": [
-        "We explicitly require symfony/browser-kit: ~4.0 since composer update --prefer-lowest will downgrade to ~3.0 breaking our Behat tests."
+        "We explicitly require symfony/browser-kit: ~4.0 otherwise composer update will downgrade to ~3.0 breaking our Behat tests."
     ],
     "scripts": {
         "post-root-package-install": [

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "webflo/drupal-core-require-dev": "~8.7"
     },
     "_readme": [
-        "We explicitly require symfony/browser-kit: ~4.0 since behat tests break with lower versions."
+        "We explicitly require symfony/browser-kit: ~4.0 since composer update --prefer-lowest will downgrade to ~3.0 breaking our Behat tests."
     ],
     "scripts": {
         "post-root-package-install": [

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "webflo/drupal-core-require-dev": "~8.7"
     },
     "_readme": [
-        "We explicitly require symfony/browser-kit: ~4.0 composer update will downgrade to ~3.0 breaking our Behat tests."
+        "We explicitly require symfony/browser-kit: ~4.0 since behat tests break with lower versions."
     ],
     "scripts": {
         "post-root-package-install": [

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,12 @@
         "drupal/console": "~1.6",
         "drupal/drupal-extension": "~4.0",
         "ec-europa/toolkit": "~4.0.0-beta7",
+        "symfony/browser-kit": "~4.0",
         "webflo/drupal-core-require-dev": "~8.7"
     },
+    "_readme": [
+        "We explicitly require symfony/browser-kit: ~4.0 composer update will downgrade to ~3.0 breaking our Behat tests."
+    ],
     "scripts": {
         "post-root-package-install": [
             "DrupalSiteTemplate\\composer\\SetupWizard::setup"


### PR DESCRIPTION
## OPENEUROPA-2186

### Description

Put minimum version for symfony/browser-kit to ~4.0.