### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 by default in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: &env
       - DOCUMENT_ROOT=/test/drupal-site-template
       - DRUPAL_DATABASE_NAME=digit_drupal_site_test_reference
@@ -30,7 +30,7 @@ pipeline:
   # Remove the cache for internal use.
   clean-repo:
     group: init
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     volumes:
       - /cache:/cache
@@ -43,7 +43,7 @@ pipeline:
   # Create project command.
   composer-create-project:
     group: create-project
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     volumes:
       - /cache:/cache
@@ -62,7 +62,7 @@ pipeline:
   # Install the drupal site.
   site-install:
     group: installation-site
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     commands:
       - cd digit-drupal-site-test-reference
@@ -71,7 +71,7 @@ pipeline:
   # Export of the configuration.
   export-config:
     group: export-config
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     commands:
       - cd digit-drupal-site-test-reference
@@ -80,7 +80,7 @@ pipeline:
   # Run grumphp tests.
   test-grumphp:
     group: test
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     commands:
       - cd digit-drupal-site-test-reference
@@ -89,7 +89,7 @@ pipeline:
   # Run behat tests.
   test-behat:
     group: test
-    image: fpfis/httpd-php-ci:${PHP_VERSION=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment: *env
     commands:
       - cd digit-drupal-site-test-reference

--- a/composer.json
+++ b/composer.json
@@ -83,9 +83,6 @@
         "drupal/drupal": "*"
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.1.9"
-        }
+        "sort-packages": true
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage by default in docker-compose and drone.