### PR TITLE
MULTISITE-23419: Proposed workaround for cli maxlength command issue.

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -10,7 +10,8 @@ parameters:
     - inc
     - theme
     - install
-    - yml
+    - info.yml
+    - routing.yml
 
   extensions:
     - OpenEuropa\CodeReview\ExtraTasksExtension


### PR DESCRIPTION
## MULTISITE-23419

### Description

Because of the config/ folder that can contain large amounts of yml files, grumphp can generate a command that exceeds the maximum characters allowed in a command. When this happens, phpcs will fail without any report.

### Change log

- Added:
- Changed: grumphp.yml.dist
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

To replicate the issue execute the grumphp command on a codebase with a large amount of yml files in the config folder:

```sh
./vendor/bin/grumphp run -vvv
```

This pull request is a simple workaround to lower the number of yml files that will be checked without excluding any files that would have to be checked by the coder package:

https://github.com/pfrenssen/coder/search?q=yml&unscoped_q=yml

